### PR TITLE
Change name of NamedTrajectory field `traj.T` to `traj.N`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
@@ -22,7 +22,7 @@ PlottingExt = ["Makie"]
 
 [compat]
 DataInterpolations = "8.1"
-JLD2 = "0.5"
+JLD2 = "0.6"
 LazyArrays = "2.6"
 Makie = "0.21, 0.22"
 OrderedCollections = "1.8"

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Users can define `NamedTrajectory` types which have lots of useful functionality
 using NamedTrajectories
 
 # define number of timesteps and timestep
-T = 10
+N = 10
 timestep=:dt
 
 # build named tuple of components and data matrices
 components = (
-    x  = rand(3, T),
-    u  = rand(2, T),
-    dt = fill(0.1, T),
+    x  = rand(3, N),
+    u  = rand(2, N),
+    dt = fill(0.1, N),
 )
 
 # build trajectory
@@ -123,28 +123,28 @@ where $\mathbf{Z}$ is a trajectory.
 In more detail, this problem might look something like
 ```math
 \begin{align*}
-\underset{u^1_{1:T}, \dots, u^{n_c}_{1:T}}{\underset{x^1_{1:T}, \cdots, x^{n_s}_{1:T}}{\text{minimize}}} &\quad J \left(x^{1:n_s}_{1:T},u^{1:n_c}_{1:T} \right) \\
-\text{subject to} & \quad f \left(x^{1:n_s}_{1:T},u^{1:n_c}_{1:T} \right) = 0 \\
+\underset{u^1_{1:N}, \dots, u^{n_c}_{1:N}}{\underset{x^1_{1:N}, \cdots, x^{n_s}_{1:N}}{\text{minimize}}} &\quad J \left(x^{1:n_s}_{1:N},u^{1:n_c}_{1:N} \right) \\
+\text{subject to} & \quad f \left(x^{1:n_s}_{1:N},u^{1:n_c}_{1:N} \right) = 0 \\
 & \quad x^i_1 = x^i_{\text{initial}} \\
-& \quad x^i_T = x^i_{\text{final}} \\
+& \quad x^i_N = x^i_{\text{final}} \\
 & \quad u^i_1 = u^i_{\text{initial}} \\
-& \quad u^i_T = u^i_{\text{final}} \\
-& \quad x^i_{\min} < x^i_t < x^i_{\max} \\
-& \quad u^i_{\min} < u^i_t < u^i_{\max} \\
+& \quad u^i_N = u^i_{\text{final}} \\
+& \quad x^i_{\min} < x^i_k < x^i_{\max} \\
+& \quad u^i_{\min} < u^i_k < u^i_{\max} \\
 \end{align*}
 ```
-where $x^i_t$ is the $i$ th state variable and $u^i_t$ is the $i$ th control variable at timestep $t$; state and control variables can be of arbitrary dimension. The function $f$ is a nonlinear constraint function and $J$ is the objective function. These problems can have an arbitrary number of state ($n_s$) and control ($n_c$) variables, and the number of timesteps $T$ can vary as well.
+where $x^i_k$ is the $i$ th state variable and $u^i_k$ is the $i$ th control variable at knot point $k$; state and control variables can be of arbitrary dimension. The function $f$ is a nonlinear constraint function and $J$ is the objective function. These problems can have an arbitrary number of state ($n_s$) and control ($n_c$) variables, and the number of knot points $N$ can vary as well.
 
 It is common practice in trajectory optimization to bundle all of the state and control variables together into a single *knot point*
 
 ```math
-z_t = \begin{pmatrix}
-    x^1_t \\
+z_k = \begin{pmatrix}
+    x^1_k \\
     \vdots \\
-    x^{n_s}_t \\
-    u^1_t \\
+    x^{n_s}_k \\
+    u^1_k \\
     \vdots \\
-    u^{n_c}_t
+    u^{n_c}_k
   \end{pmatrix}.
 ```
 
@@ -152,11 +152,11 @@ The trajectory optimization problem can then be succinctly written as
 
 ```math
 \begin{align*}
-\underset{z_{1:T}}{\text{minimize}} &\quad J \left(z_{1:T} \right) \\
-\text{subject to} & \quad f \left(z_{1:T} \right) = 0 \\
+\underset{z_{1:N}}{\text{minimize}} &\quad J \left(z_{1:N} \right) \\
+\text{subject to} & \quad f \left(z_{1:N} \right) = 0 \\
 & \quad z_1 = z_{\text{initial}} \\
-& \quad z_T = z_{\text{final}} \\
-& \quad z_{\min} < z_t < z_{\max} \\
+& \quad z_N = z_{\text{final}} \\
+& \quad z_{\min} < z_k < z_{\max} \\
 \end{align*}
 ```
 

--- a/docs/literate/man/constructors.jl
+++ b/docs/literate/man/constructors.jl
@@ -5,15 +5,15 @@
 using NamedTrajectories
 
 ## define number of timesteps and timestep
-T = 10
+N = 10
 dt = 0.1
 
 # build named tuple of components and data matrices.
 
 components = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = fill(dt, 1, T),
+    x = rand(3, N),
+    u = rand(2, N),
+    Δt = fill(dt, 1, N),
 )
 
 # we must specify a timestep and control variable for the trajectory.

--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -113,16 +113,16 @@ println(traj.components)
 # For instance, the indices of a given component at a given knot point are given as follows:
 
 idx = 1 # x
-t = 3
-slice = traj.datavec[((t - 1) * traj.T) .+ traj.components[traj.names[idx]]]
-println(slice == traj[t].x == traj.x[:, t])
+k = 3
+slice = traj.datavec[((k - 1) * traj.N) .+ traj.components[traj.names[idx]]]
+println(slice == traj[k].x == traj.x[:, k])
 
 # More generally, the indices of a given component across all knot points are given as follows:
 
 idx = 1 # x
-println([((k - 1) * traj.dim) .+ getproperty(traj.components, traj.names[idx]) for k in 1:traj.T])
+println([((k - 1) * traj.dim) .+ getproperty(traj.components, traj.names[idx]) for k in 1:traj.N])
 idx = 2 # u
-println([((k - 1) * traj.dim) .+ getproperty(traj.components, traj.names[idx]) for k in 1:traj.T])
+println([((k - 1) * traj.dim) .+ getproperty(traj.components, traj.names[idx]) for k in 1:traj.N])
 
 
 # ### Writability
@@ -154,7 +154,7 @@ fieldnames(NamedTrajectory)
 #=
 TODO:
 - Prevent this issue by catching attempts to set sensitive fields in `Base.setproperty!(::NamedTrajectory, ::Symbol, ::Any)` (`datavec` and `data` are the primary concern in this regard; however, issuing a warning of some kind may be appropriate).
-    - Particularly because it is confusing that `traj.datavec = zeros(length(datavec))` is "discouraged", while `traj.x = zeros(traj.dims.x, traj.T)` and `traj[1].x = zeros(traj.dims.x)` are both valid.
+    - Particularly because it is confusing that `traj.datavec = zeros(length(datavec))` is "discouraged", while `traj.x = zeros(traj.dims.x, traj.N)` and `traj[1].x = zeros(traj.dims.x)` are both valid.
 =#
 
 # #### Components and Knot Points
@@ -167,7 +167,7 @@ traj.x
 
 # Components are also writable via `setproperty!`:
 
-traj.x = rand(traj.dims.x, traj.T)
+traj.x = rand(traj.dims.x, traj.N)
 traj.x
 
 # or may be modified directly:

--- a/docs/literate/man/params_in_struct.jl
+++ b/docs/literate/man/params_in_struct.jl
@@ -4,14 +4,14 @@
 using NamedTrajectories
 
 # First we need to define number of timesteps and timestep
-T = 10
+N = 10
 dt = 0.1
 
 # then build named tuple of components and data matrices.
 components = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = fill(dt, 1, T),
+    x = rand(3, N),
+    u = rand(2, N),
+    Δt = fill(dt, 1, N),
 )
 
 # we must specify a timestep and control variable for the trajectory.

--- a/docs/literate/plotting.jl
+++ b/docs/literate/plotting.jl
@@ -36,15 +36,15 @@ using CairoMakie
 using NamedTrajectories
 
 ## define the number timestamps
-T = 100
+N = 100
 Δt = 0.1
-ts = [0:T-1...] * Δt
+ts = [0:N-1...] * Δt
 
 ## define sinusoidal state trajectories
-X = zeros(3, T)
-X[1, :] = sin.(3 * 2π * ts / (2 * (T - 1) * Δt))
-X[2, :] = -sin.(5 * 2π * ts / (2 * (T - 1) * Δt))
-X[3, :] = sin.(9 * 2π * ts / (2 * (T - 1) * Δt))
+X = zeros(3, N)
+X[1, :] = sin.(3 * 2π * ts / (2 * (N - 1) * Δt))
+X[2, :] = -sin.(5 * 2π * ts / (2 * (N - 1) * Δt))
+X[3, :] = sin.(9 * 2π * ts / (2 * (N - 1) * Δt))
 
 ## define gaussian shaped controls
 U = stack(
@@ -62,7 +62,7 @@ traj = NamedTrajectory(
         x=X,
         u=U,
         v=V,
-        Δt=fill(Δt, T),
+        Δt=fill(Δt, N),
     );
     timestep=:Δt,
     controls=(:u, :v)

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -17,10 +17,10 @@ using NamedTrajectories
 
 #=
 ```math
-\qty{z_t = \mqty(x_t \\ u_t)}_{t=1:T}
+\qty{z_k = \mqty(x_k \\ u_k)}_{k=1:N}
 ```
 
-where $x_t$ is the state and $u_t$ is the control at a time indexed by $t$. Together $z_t$ is referred to as a *knot point* and a `NamedTrajectory` essentially just stores a collection of knot points and makes it easy to access the state and control variables.
+where $x_k$ is the state and $u_k$ is the control at a time indexed by $k$. Together $z_k$ is referred to as a *knot point* and a `NamedTrajectory` essentially just stores a collection of knot points and makes it easy to access the state and control variables.
 
 ## Creating a variable-timestep `NamedTrajectory`
 
@@ -28,14 +28,14 @@ Here we will create a `NamedTrajectory` with a variable timestep.
 =#
 
 ## define the number of timesteps
-T = 10
+N = 10
 Δt = 0.1
 
 ## define the knot point data as a NamedTuple of matrices
 data = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = fill(Δt, T),
+    x = rand(3, N),
+    u = rand(2, N),
+    Δt = fill(Δt, N),
 )
 
 ## we must specify a timestep and control variable for the NamedTrajectory.
@@ -56,13 +56,13 @@ In many settings we will want to specify the problem data of our `NamedTrajector
 =#
 
 ## define the number of timesteps
-T = 10
+N = 10
 
 ## define the knot point data as a NamedTuple of matrices
 data = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = rand(T),
+    x = rand(3, N),
+    u = rand(2, N),
+    Δt = rand(N),
 )
 
 ## define initial values
@@ -151,7 +151,7 @@ traj.dims
 
 # returns the dimensions of the variables stored in the trajectory.
 
-traj.T
+traj.N
 
 # returns the number of knot points in the trajectory.
 

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -17,7 +17,7 @@ function Makie.convert_arguments(
     P::Makie.PointBased,
     traj::NamedTrajectory,
     comp::Int;
-    indices::AbstractVector{Int}=1:traj.T
+    indices::AbstractVector{Int}=1:traj.N
 )
     times = get_times(traj)[indices]
     positions = map(zip(indices, times)) do (i, t)
@@ -35,7 +35,7 @@ function Makie.convert_arguments(
     traj::NamedTrajectory,
     name::Symbol;
     transform::Union{Nothing, AbstractTransform}=nothing,
-    indices::AbstractVector{Int}=1:traj.T
+    indices::AbstractVector{Int}=1:traj.N
 )
     if !isnothing(transform)
         transform_data = try
@@ -107,7 +107,7 @@ function Makie.plot!(
         markersize = isnothing(P[:marker][]) ? nothing :  P[:markersize]
 
         # Empty indices means all indices
-        indices = isnothing(P[:indices][]) ? range(1, traj.T) : P[:indices][]
+        indices = isnothing(P[:indices][]) ? range(1, traj.N) : P[:indices][]
 
         series!(
             P, traj, name;
@@ -156,7 +156,7 @@ function Makie.plot!(
         markersize = isnothing(P[:marker][]) ? nothing :  P[:markersize]
 
         # Empty indices means all indices
-        indices = isnothing(P[:indices][]) ? range(1, traj.T) : P[:indices][]
+        indices = isnothing(P[:indices][]) ? range(1, traj.N) : P[:indices][]
 
         series!(
             P, traj, input;

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -15,18 +15,18 @@ function Base.show(io::IO, Z::NamedTrajectory)
 
     comp_str = join([format(n, Z.components[n]) for n in keys(Z.components)], ", ")
     if isempty(Z.global_data)
-        print(io, "T = ", Z.T, ", (", comp_str, ")")
+        print(io, "N = ", Z.N, ", (", comp_str, ")")
     else
         global_comp_str = join([format(n, Z.global_components[n]) for n in keys(Z.global_components)], ", ")
-        print(io, "T = ", Z.T, ", (", comp_str, "), (", global_comp_str, ")")
+        print(io, "N = ", Z.N, ", (", comp_str, "), (", global_comp_str, ")")
     end
 end
 
 """
-    length(Z::NamedTrajectory) = Z.dim * Z.T + Z.global_dim
+    length(Z::NamedTrajectory) = Z.dim * Z.N + Z.global_dim
 """
 function Base.length(Z::NamedTrajectory)
-    return Z.dim * Z.T + Z.global_dim
+    return Z.dim * Z.N + Z.global_dim
 end
 
 """
@@ -39,9 +39,9 @@ function Base.vec(Z::NamedTrajectory)
 end
 
 """
-    size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, global_dim = Z.global_dim)
+    size(Z::NamedTrajectory) = (dim = Z.dim, N = Z.N, global_dim = Z.global_dim)
 """
-Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, global_dim = Z.global_dim)
+Base.size(Z::NamedTrajectory) = (dim = Z.dim, N = Z.N, global_dim = Z.global_dim)
 
 """
     copy(::NamedTrajectory)
@@ -51,7 +51,7 @@ Returns a shallow copy of the trajectory.
 function Base.copy(traj::NamedTrajectory)
     NamedTrajectory(
         traj.datavec,
-        traj.T,
+        traj.N,
         traj.timestep,
         traj.dim,
         traj.dims,
@@ -76,35 +76,35 @@ end
 # -------------------------------------------------------------- #
 
 """
-    KnotPoint(Z::NamedTrajectory, t::Int)
+    KnotPoint(Z::NamedTrajectory, k::Int)
 
     # Arguments
     - `Z::NamedTrajectory`: The trajectory from which the KnotPoint is taken.
-    - `t::Int`: The timestep of the KnotPoint.
+    - `k::Int`: The timestep of the KnotPoint.
 """
 function StructKnotPoint.KnotPoint(
     Z::NamedTrajectory,
-    t::Int
+    k::Int
 )
-    @assert 1 ≤ t ≤ Z.T
-    timestep = Z[Z.timestep][t]
-    return KnotPoint(t, view(Z.data, :, t), timestep, Z.components, Z.names, Z.control_names)
+    @assert 1 ≤ k ≤ Z.N
+    timestep = Z[Z.timestep][k]
+    return KnotPoint(k, view(Z.data, :, k), timestep, Z.components, Z.names, Z.control_names)
 end
 
 """
-    getindex(traj, t::Int)::KnotPoint
+    getindex(traj, k::Int)::KnotPoint
 
-Returns the knot point at time `t`.
+Returns the knot point at time `k`.
 """
-Base.getindex(traj::NamedTrajectory, t::Int) = KnotPoint(traj, t)
+Base.getindex(traj::NamedTrajectory, k::Int) = KnotPoint(traj, k)
 
 """
-    getindex(traj, ts::AbstractVector{Int})::Vector{KnotPoint}
+    getindex(traj, ks::AbstractVector{Int})::Vector{KnotPoint}
 
-Returns the knot points at times `ts`.
+Returns the knot points at times `ks`.
 """
-function Base.getindex(traj::NamedTrajectory, ts::AbstractVector{Int})::Vector{KnotPoint}
-    return [traj[t] for t ∈ ts]
+function Base.getindex(traj::NamedTrajectory, ks::AbstractVector{Int})::Vector{KnotPoint}
+    return [traj[k] for k ∈ ks]
 end
 
 """
@@ -112,7 +112,7 @@ end
 
 Returns the final time index of the trajectory.
 """
-Base.lastindex(traj::NamedTrajectory) = traj.T
+Base.lastindex(traj::NamedTrajectory) = traj.N
 
 """
     getindex(traj, symb::Symbol)
@@ -128,7 +128,7 @@ Returns the component of the trajectory with name `symb` (as a view) or the prop
 """
 function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
     if symb == :data
-        return reshape(view(traj.datavec, :), :, traj.T)
+        return reshape(view(traj.datavec, :), :, traj.N)
     elseif symb ∈ fieldnames(NamedTrajectory)
         return getfield(traj, symb)
     elseif symb in traj.names
@@ -210,14 +210,14 @@ Base.:*(traj::NamedTrajectory, α::Float64) = α * NamedTrajectory(traj)
 function Base.:+(traj1::NamedTrajectory, traj2::NamedTrajectory)
     @assert traj1.names == traj2.names
     @assert traj1.dim == traj2.dim
-    @assert traj1.T == traj2.T
+    @assert traj1.N == traj2.N
     return NamedTrajectory(traj1, datavec=traj1.datavec + traj2.datavec)
 end
 
 function Base.:-(traj1::NamedTrajectory, traj2::NamedTrajectory)
     @assert traj1.names == traj2.names
     @assert traj1.dim == traj2.dim
-    @assert traj1.T == traj2.T
+    @assert traj1.N == traj2.N
     return NamedTrajectory(traj1, datavec=traj1.datavec - traj2.datavec)
 end
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -69,7 +69,7 @@ end
     x_new = rand(size(x_orig)...)
     u_new = rand(size(u_orig)...)
 
-    idx = rand(1:traj.T)
+    idx = rand(1:traj.N)
 
     traj[idx].x = deepcopy(x_new[:, idx])
     @test traj.x[:, idx] == traj.data[traj.components.x, idx] == traj[idx].x == x_new[:, idx]

--- a/src/random_trajectories.jl
+++ b/src/random_trajectories.jl
@@ -7,7 +7,7 @@ using ..StructNamedTrajectory
 """
     rand(
         ::Type{NamedTrajectory},
-        T::Int;
+        N::Int;
         timestep_value::Float64=1.0,
         timestep_name::Symbol=:Δt,
         timestep::Union{Float64,Symbol}=free_time ? timestep_name : timestep_value,
@@ -15,11 +15,11 @@ using ..StructNamedTrajectory
         control_dim::Int=2
     )
 
-Create a random `NamedTrajectory` with `T` time steps, a state variable `x` of dimension  `state_dim`, and a control variable `u` of dimension `control_dim`. The time step is a symbol `timestep_name` and the time step value is `timestep_value`. 
+Create a random `NamedTrajectory` with `N` knot points, a state variable `x` of dimension  `state_dim`, and a control variable `u` of dimension `control_dim`. The time step is a symbol `timestep_name` and the time step value is `timestep_value`. 
 """
 function Base.rand(
     ::Type{NamedTrajectory},
-    T::Int;
+    N::Int;
     timestep_value::Float64=1.0,
     timestep::Symbol=:Δt,
     state::Symbol=:x,
@@ -28,9 +28,9 @@ function Base.rand(
     control_dim::Int=2
 )
     comps_data = (;
-        state => randn(state_dim, T),
-        control => randn(control_dim, T),
-        timestep => fill(timestep_value, 1, T)
+        state => randn(state_dim, N),
+        control => randn(control_dim, N),
+        timestep => fill(timestep_value, 1, N)
     )
 
     return NamedTrajectory(comps_data;  timestep=timestep, controls=(control, timestep))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,13 +1,13 @@
 using Random
 
 function get_free_time_traj(;
-    T::Int=5, 
+    N::Int=5, 
     Δt::Symbol=:Δt, 
     x_dim::Int=3, 
     a_dim::Int=2,
     kwargs...
 )
-    free_time_data = (x = rand(x_dim, T), u = rand(a_dim, T), Δt = rand(1, T))
+    free_time_data = (x = rand(x_dim, N), u = rand(a_dim, N), Δt = rand(1, N))
     return NamedTrajectory(free_time_data; timestep=Δt, controls=:u, kwargs...)
 end
 


### PR DESCRIPTION
This pull request standardizes the terminology and variable names across the codebase and documentation for the `NamedTrajectory` type. Specifically, it replaces the use of `T` (for the number of timesteps) with `N` (for the number of knot points) everywhere, and updates related variable names and documentation to use "knot point" and `k` instead of "timestep" and `t`. This improves clarity and consistency, especially for users familiar with trajectory optimization literature.

The most important changes are:

**API and Core Type Updates:**

* Replaced all uses of `T` (timesteps) with `N` (knot points) in the `NamedTrajectory` type, associated methods, and their documentation, including properties like `traj.T` → `traj.N`, and related assertions and indexing. [[1]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL18-R29) [[2]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL42-R44) [[3]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL54-R54) [[4]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL79-R115) [[5]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL131-R131) [[6]](diffhunk://#diff-68efc2643315fdd72c4d635bbfcc5d4bf427c2e0b63f81958e8658bfec6f793eL213-R220) [[7]](diffhunk://#diff-2fdd58b9199e43b16b70cde6ccb2a347e045f78f408279a5063d7cdcf22ce2a7L98-R98) [[8]](diffhunk://#diff-2fdd58b9199e43b16b70cde6ccb2a347e045f78f408279a5063d7cdcf22ce2a7L111-R111) [[9]](diffhunk://#diff-2fdd58b9199e43b16b70cde6ccb2a347e045f78f408279a5063d7cdcf22ce2a7L133-R141) [[10]](diffhunk://#diff-2fdd58b9199e43b16b70cde6ccb2a347e045f78f408279a5063d7cdcf22ce2a7L186-R186) [[11]](diffhunk://#diff-a7298efef76bb2d17b97f73448bdabe99f263a490cf18e73b8a8c5d5fd8e2a55L72-R72)

**Documentation and Example Updates:**

* Updated all documentation, literate examples, and README code snippets to use `N` for the number of knot points instead of `T`, and to use `k` for the knot point index instead of `t`. This includes example code, math expressions, and explanatory text. (README.md: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L126-R159); docs/literate/man/constructors.jl: [[3]](diffhunk://#diff-53d6a2ecff6c235684b6277a69c1a32c1ecb1064117f3a652d842c639ef1f07fL8-R16); docs/literate/man/modifying.jl: [[4]](diffhunk://#diff-4f1dde467c22eeaac41178dfc9f19d3013bf14434516a210abd7d0b1b0ecbec8L116-R125) [[5]](diffhunk://#diff-4f1dde467c22eeaac41178dfc9f19d3013bf14434516a210abd7d0b1b0ecbec8L157-R157) [[6]](diffhunk://#diff-4f1dde467c22eeaac41178dfc9f19d3013bf14434516a210abd7d0b1b0ecbec8L170-R170); docs/literate/man/params_in_struct.jl: [[7]](diffhunk://#diff-29a582e3ae455f0d7cae36c688a1577e336efa9be0ae3d4a56072366c98c1e3eL7-R14); docs/literate/plotting.jl: [[8]](diffhunk://#diff-79395951b09b866cfe704cc459cc612ea94660cd71e5961bcbe45227ce9e9073L39-R47) [[9]](diffhunk://#diff-79395951b09b866cfe704cc459cc612ea94660cd71e5961bcbe45227ce9e9073L65-R65); docs/literate/quickstart.jl: [[10]](diffhunk://#diff-02997fd9d076eb7870ab4168a2fbb94345394a2ed57ec03ab00c304c97252040L20-R38) [[11]](diffhunk://#diff-02997fd9d076eb7870ab4168a2fbb94345394a2ed57ec03ab00c304c97252040L59-R65) [[12]](diffhunk://#diff-02997fd9d076eb7870ab4168a2fbb94345394a2ed57ec03ab00c304c97252040L154-R154)

**Plotting Extension Updates:**

* Changed plotting extension code to use `traj.N` instead of `traj.T` for indices and ranges, ensuring plotting functions are consistent with the new terminology. [[1]](diffhunk://#diff-435001c7a9d5f1311a6bbe36e93fbea75895f135de3cb97c3ce6ff64fdcd845fL20-R20) [[2]](diffhunk://#diff-435001c7a9d5f1311a6bbe36e93fbea75895f135de3cb97c3ce6ff64fdcd845fL38-R38) [[3]](diffhunk://#diff-435001c7a9d5f1311a6bbe36e93fbea75895f135de3cb97c3ce6ff64fdcd845fL110-R110) [[4]](diffhunk://#diff-435001c7a9d5f1311a6bbe36e93fbea75895f135de3cb97c3ce6ff64fdcd845fL159-R159)

These changes collectively improve codebase clarity, reduce ambiguity, and align the terminology with standard practices in trajectory optimization.