### PR TITLE
update documentation 

### DIFF
--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -103,7 +103,7 @@ traj.data
 
 # ### Indexing
 
-# The `data` matrix is of dimension `(traj.dim, traj.T)`, where `length(traj.names) == traj.dim`
+# The `data` matrix is of dimension `(traj.dim, traj.N)`, where `length(traj.names) == traj.dim`
 
 # The nth component's indices are given by `traj.components[traj.names[n]]`
 


### PR DESCRIPTION
This pull request makes a small documentation correction to the `traj.data` section in `docs/literate/man/modifying.jl`, clarifying the dimensions of the `data` matrix.

- Updated the documentation to specify that the `data` matrix is of dimension `(traj.dim, traj.N)` instead of `(traj.dim, traj.T)`.