### PR TITLE
test: cover edge cases and lift coverage 84% → 94%

### DIFF
--- a/ext/InterpolationsExt.jl
+++ b/ext/InterpolationsExt.jl
@@ -449,6 +449,37 @@ end
     resR = interp_ch_const(tmax + 1.0)
     @test resR isa Vector{Float64}
     @test length(resR) == u_dim
+
+    # Non-constant extrapolation skips the wrapper and returns the bare interpolation.
+    interp_none = LinearInterpolation(traj, :x; extrapolation = ExtrapolationType.None)
+    @test interp_none isa LinearInterpolation
+end
+
+@testitem "extrapolation wrapper handles scalar-valued (1D) u" begin
+    # NT-aware constructors always pass 2D data, but the internal helpers are
+    # written defensively for 1D u as well. Exercise that branch directly.
+    using DataInterpolations
+    Ext = Base.get_extension(NamedTrajectories, :InterpolationsExt)
+
+    u1d = [10.0, 20.0, 30.0, 40.0]
+    @test Ext._boundary_value(u1d, 1) == 10.0
+    @test Ext._boundary_value(u1d, 4) == 40.0
+
+    times = [0.0, 1.0, 2.0, 3.0]
+    interp = ConstantInterpolation(u1d, times)
+    wrapped = Ext._maybe_wrap_constant_extrapolation(
+        interp;
+        extrapolation = ExtrapolationType.Constant,
+    )
+    @test wrapped isa Ext._ConstantExtrapolationFix
+    @test wrapped(-1.0) == 10.0
+    @test wrapped(10.0) == 40.0
+
+    arr = wrapped([-1.0, 1.5, 10.0])
+    @test arr isa AbstractVector
+    @test length(arr) == 3
+    @test arr[1] == 10.0
+    @test arr[3] == 40.0
 end
 
 @testitem "interpolation basic functionality" begin
@@ -499,6 +530,38 @@ end
     # Check that new data matches the constant values
     @test all(new_traj[:x] .== 1.0)
     @test all(new_traj[:y] .== 0.0)
+end
+
+@testitem "trajectory_interpolation: T::Int variant and mixed kinds" begin
+    using DataInterpolations
+
+    T = 8
+    x_dim = 2
+    u_dim = 2
+    traj_init = rand(NamedTrajectory, T, control_dim = u_dim, state_dim = x_dim)
+    traj = add_component(traj_init, :du, rand(u_dim, T))
+
+    # T::Int variant should produce a trajectory with that many knot points.
+    new_traj = trajectory_interpolation(traj, 2T)
+    @test size(new_traj.data, 2) == 2T
+
+    # Mixing :constant, :linear, :spline, with the timestep auto-merged.
+    interpolations = (x = :constant, u = :spline)
+    mixed = trajectory_interpolation(
+        traj,
+        collect(range(get_times(traj)[1], get_times(traj)[end], length = 2T));
+        interpolations = interpolations,
+    )
+    @test size(mixed.data, 2) == 2T
+    @test :x ∈ mixed.names
+    @test :u ∈ mixed.names
+
+    # Unsupported kind raises an ArgumentError.
+    @test_throws ArgumentError trajectory_interpolation(
+        traj,
+        get_times(traj);
+        interpolations = (x = :nonsense,),
+    )
 end
 
 end

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -342,4 +342,97 @@ end
     @test vec(traj) == vcat(traj.datavec, traj.global_data)
 end
 
+@testitem "size returns (dim, N, global_dim)" begin
+    traj = NamedTrajectory(
+        randn(5, 10),
+        (x = 1:3, y = 4:4, z = 5:5);
+        timestep = :z,
+        global_data = [1.0, 2.0, 3.0],
+        global_components = (a = 1:2, b = 3:3),
+    )
+    sz = size(traj)
+    @test sz.dim == 5
+    @test sz.N == 10
+    @test sz.global_dim == 3
+end
+
+@testitem "show prints components and global components" begin
+    traj_no_global = NamedTrajectory(randn(3, 4), (x = 1:2, z = 3:3); timestep = :z)
+    str_no_global = sprint(show, traj_no_global)
+    @test occursin("N = 4", str_no_global)
+    @test occursin("→ z", str_no_global)
+    @test occursin("x", str_no_global)
+    @test !occursin("),  (", str_no_global)
+
+    traj_global = NamedTrajectory(
+        randn(3, 4),
+        (x = 1:2, z = 3:3);
+        timestep = :z,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+    str_global = sprint(show, traj_global)
+    @test occursin("N = 4", str_global)
+    @test occursin("g = 1:2", str_global)
+end
+
+@testitem "getindex with vector of integers returns vector of knot points" begin
+    traj = rand(NamedTrajectory, 6)
+    knots = traj[2:4]
+    @test knots isa Vector
+    @test length(knots) == 3
+    @test knots[1].x == traj[2].x
+    @test knots[end].x == traj[4].x
+end
+
+@testitem "isequal mismatch branches" begin
+    base = NamedTrajectory(
+        randn(4, 5),
+        (x = 1:2, y = 3:3, z = 4:4);
+        timestep = :z,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+
+    # Mismatched component names: rebuild with a different component name set.
+    differ_names = NamedTrajectory(
+        randn(4, 5),
+        (x = 1:2, w = 3:3, z = 4:4);
+        timestep = :z,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+    @test !isequal(base, differ_names)
+
+    # Same names, different component data.
+    differ_values = NamedTrajectory(
+        randn(4, 5),
+        (x = 1:2, y = 3:3, z = 4:4);
+        timestep = :z,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+    @test !isequal(base, differ_values)
+
+    # Mismatched global names.
+    differ_globals = NamedTrajectory(
+        copy(base.data),
+        (x = 1:2, y = 3:3, z = 4:4);
+        timestep = :z,
+        global_data = [1.0, 2.0],
+        global_components = (h = 1:2,),
+    )
+    @test !isequal(base, differ_globals)
+
+    # Same global names, different global values.
+    differ_global_values = NamedTrajectory(
+        copy(base.data),
+        (x = 1:2, y = 3:3, z = 4:4);
+        timestep = :z,
+        global_data = [3.0, 4.0],
+        global_components = (g = 1:2,),
+    )
+    @test !isequal(base, differ_global_values)
+end
+
 end

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -97,4 +97,24 @@ end
           u_orig[:, idx]
 end
 
+@testitem "KnotPoint getindex via Symbol" begin
+    traj = rand(NamedTrajectory, 6)
+    kp = traj[3]
+
+    # Component access via getindex: should return view of slice data.
+    x_view = kp[:x]
+    @test x_view == traj.x[:, 3]
+    @test x_view == kp.x
+
+    # Field access via getindex: returns the underlying field value, not a view.
+    @test kp[:components] === kp.components
+end
+
+@testitem "KnotPoint setproperty! on a struct field errors" begin
+    traj = rand(NamedTrajectory, 4)
+    kp = traj[2]
+    # KnotPoint is immutable; assigning to a struct field must error.
+    @test_throws ErrorException kp.components = kp.components
+end
+
 end

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -1296,4 +1296,55 @@ end
 #                   Add control derivatives to trajectory                       #
 # ============================================================================= #
 
+@testitem "get_components without name list returns all components" begin
+    traj = NamedTrajectory(randn(4, 5), (x = 1:2, u = 3:3, z = 4:4); timestep = :z)
+    comps = get_components(traj)
+    @test keys(comps) == (:x, :u, :z)
+    @test comps.x == traj[:x]
+    @test comps.u == traj[:u]
+end
+
+@testitem "get_component_names: success and error" begin
+    traj = NamedTrajectory(randn(4, 5), (x = 1:2, u = 3:3, z = 4:4); timestep = :z)
+    @test get_component_names(traj, [1, 2]) == [:x]
+    @test get_component_name(traj, [1, 2]) == :x
+    # Indices that don't fully contain any component → error
+    @test_throws ErrorException get_component_names(traj, [99])
+    # Indices that contain multiple components → multiple-name error
+    @test_throws ErrorException get_component_name(traj, [1, 2, 3, 4])
+end
+
+@testitem "get_timesteps and get_duration with symbol timestep" begin
+    data = randn(4, 5)
+    traj = NamedTrajectory(data, (x = 1:3, z = 4:4); timestep = :z)
+    @test get_timesteps(traj) == vec(traj[:z])
+    expected_times = cumsum([0.0, vec(traj[:z])[1:(end-1)]...])
+    @test get_duration(traj) == expected_times[end]
+end
+
+@testitem "merge_outer on tuples and collision detection" begin
+    merge_outer = NamedTrajectories.MethodsNamedTrajectory.merge_outer
+    @test merge_outer((:a, :b), (:c, :d)) == (:a, :b, :c, :d)
+    @test_throws ArgumentError merge_outer((:a, :b), (:b, :c))
+    @test_throws ArgumentError merge_outer((x = 1,), (x = 2,))
+end
+
+@testitem "merge with fewer than two trajectories raises" begin
+    traj = NamedTrajectory(randn(3, 4), (x = 1:2, z = 3:3); timestep = :z)
+    @test_throws ArgumentError merge([traj])
+end
+
+@testitem "add_suffix and remove_suffix on vectors and tuples" begin
+    @test add_suffix([:a, :b], "_x") == [:a_x, :b_x]
+    @test add_suffix([:a, :b], "_x"; exclude = [:b]) == [:a_x, :b]
+
+    @test remove_suffix((:a_x, :b_x), "_x") == (:a, :b)
+    @test remove_suffix((:a_x, :b_x), "_x"; exclude = [:b_x]) == (:a, :b_x)
+    @test remove_suffix([:a_x, :b_x], "_x") == [:a, :b]
+    @test remove_suffix([:a_x, :b_x], "_x"; exclude = [:b_x]) == [:a, :b_x]
+
+    # Suffix-not-present error path
+    @test_throws ArgumentError remove_suffix("hello", "_world")
+end
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -68,4 +68,58 @@ end
 integral(X::AbstractMatrix, Δt::Float64) = integral(X, fill(Δt, size(X, 2)))
 
 
+# =========================================================================== #
+
+using TestItems
+
+@testitem "save and load_traj round-trip" begin
+    traj = rand(NamedTrajectory, 5)
+    mktempdir() do dir
+        path = joinpath(dir, "traj.jld2")
+        save(path, traj)
+        @test isfile(path)
+        loaded = load_traj(path)
+        @test isequal(loaded, traj)
+    end
+end
+
+@testitem "save/load filename extension assertion" begin
+    traj = rand(NamedTrajectory, 5)
+    @test_throws AssertionError save("bad_extension.txt", traj)
+    @test_throws AssertionError load_traj("missing.txt")
+end
+
+@testitem "derivative: vector and Float64 timesteps agree on uniform grid" begin
+    X = [1.0 2.0 4.0 7.0 11.0; 0.0 1.0 4.0 9.0 16.0]
+    Δt_vec = fill(0.5, size(X, 2))
+    dX_vec = derivative(X, Δt_vec)
+    @test size(dX_vec) == size(X)
+    @test dX_vec[:, 1] ≈ (X[:, 2] - X[:, 1]) / 0.5
+    @test dX_vec[:, end] ≈ dX_vec[:, end-1]
+
+    dX_float = derivative(X, 0.5)
+    @test dX_float ≈ dX_vec
+end
+
+@testitem "derivative: matrix Δt with single row collapses to vector" begin
+    X = randn(3, 6)
+    Δt_row = reshape(fill(0.25, 6), 1, 6)
+    dX_mat = derivative(X, Δt_row)
+    dX_vec = derivative(X, vec(Δt_row))
+    @test dX_mat ≈ dX_vec
+end
+
+@testitem "integral: vector and Float64 timesteps agree on uniform grid" begin
+    X = [1.0 2.0 3.0 4.0 5.0; 0.0 1.0 2.0 3.0 4.0]
+    Δt_vec = fill(1.0, size(X, 2))
+    ∫X = integral(X, Δt_vec)
+    @test size(∫X) == size(X)
+    @test ∫X[:, 1] == zeros(size(X, 1))
+    @test ∫X[:, 2] ≈ (X[:, 1] + X[:, 2]) / 2 * 1.0
+    @test ∫X[:, 3] ≈ ∫X[:, 2] + (X[:, 2] + X[:, 3]) / 2 * 1.0
+
+    ∫X_const = integral(X, 1.0)
+    @test ∫X_const ≈ ∫X
+end
+
 end


### PR DESCRIPTION
## Summary
- Covers the three patch-coverage gaps Codecov flagged on #106 — exercises `_boundary_value` and `_ConstantExtrapolationFix(::AbstractArray)` defensive branches via the internal helpers, and the bare-interp return path with a non-Constant extrapolation.
- Adds inline `@testitem` blocks across the package targeting previously-untested public surface.
- Lifts overall coverage from **84.24% → 93.64%** without touching any production code.

## Coverage by file

| File | Before | After |
|---|---|---|
| `utils.jl` | 48% | **100%** |
| `base_named_trajectory.jl` | 77% | **100%** |
| `methods_knot_point.jl` | 65% | 90% |
| `methods_named_trajectory.jl` | 83% | 95% |
| `InterpolationsExt.jl` | 90% | **100%** |
| `PlottingExt.jl` | 86% | 86% (unchanged — visual paths) |

## What's tested

- **utils**: `save`/`load_traj` round-trip, filename-extension assertions, `derivative` (vector/Float64/matrix-row Δt), `integral` (vector/Float64 Δt).
- **base_named_trajectory**: `show` (with and without globals), `size` field tuple, vector-indexed knot slicing (`traj[2:4]`), `isequal` across all four early-exit branches (component names, component values, global names, global values).
- **methods_knot_point**: `KnotPoint` Symbol `getindex` for both component-view and field-access paths, immutable-field assignment error.
- **methods_named_trajectory**: `get_components` no-arg form, `get_component_name(s)` success and error paths, `get_timesteps`/`get_duration` with symbol timesteps, `merge_outer` collision detection on tuples and named tuples, `merge` with fewer than two trajectories, `add_suffix`/`remove_suffix` on vectors and tuples (including the `exclude` kwarg and missing-suffix error).
- **InterpolationsExt**: `trajectory_interpolation` `T::Int` variant, mixed-kind interpolations with auto-merged timestep, unsupported-kind error, scalar-valued (1D) `u` path through the internal `_boundary_value` and `_maybe_wrap_constant_extrapolation` helpers.

No production code changed — only inline `@testitem` blocks added in each source file.

## Test plan
- [x] Local: `Pkg.test()` — 343/343 pass on Julia 1.12.
- [x] CI: Julia 1.10 / 1.11 / 1.12 + Formatter + Docs + Codecov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)