### PR TITLE
bump version to 0.9.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Cuts a 0.9.0 release covering the DataInterpolations extension changes that landed in #106 and the test/coverage work in #124.

Bumped to 0.9 (not 0.8.5) under 0.x semver because #106 has two observable behavior changes for callers passing array-valued components through the NT-aware interpolation constructors:

1. The default extrapolation flipped from `ExtrapolationType.None` (errors out of range) to `ExtrapolationType.Constant` (returns boundary slice).
2. With the new default, the constructors now return a `_ConstantExtrapolationFix` wrapper rather than the bare `ConstantInterpolation` / `LinearInterpolation` / `CubicHermiteSpline` type.

Audit of downstream usage:
- `Piccolo.jl` is unaffected — its parametric pulse structs (`{I<:ConstantInterpolation}`, etc.) are only constructed from the matrix-based path that bypasses the NT extension. Its rollout helpers in `dynamics.jl` pass the result into duck-typed ODE problem constructors.
- No other harmoniqs package references these constructors.

A separate PR will widen Piccolo.jl's compat to `NamedTrajectories = "0.8, 0.9"` so existing pins keep working.

## Test plan
- [ ] Julia 1.10 / 1.11 / 1.12 CI
- [ ] Formatter check
- [ ] Documentation build

🤖 Generated with [Claude Code](https://claude.com/claude-code)