### PR TITLE
fix: address Aqua and JET findings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ PlottingExt = ["LaTeXStrings", "Makie"]
 
 [compat]
 Aqua = "0.8"
+CairoMakie = "0.12, 0.13, 0.14, 0.15"
 DataInterpolations = "8.1"
 JET = "0.9, 0.10, 0.11"
 JLD2 = "0.6"
@@ -32,6 +33,7 @@ OrderedCollections = "1.8"
 Random = "1.10, 1.11, 1.12"
 Reexport = "1.2"
 Statistics = "1.10, 1.11"
+Test = "1.10, 1.11, 1.12"
 TestItemRunner = "1.1"
 TestItems = "1.0"
 julia = "1.10, 1.11, 1.12"

--- a/Project.toml
+++ b/Project.toml
@@ -4,27 +4,24 @@ version = "0.9.0"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]
-ComputePipeline = "95dc2771-c249-4cd0-9c9f-1f3b4330693c"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 
 [weakdeps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
 InterpolationsExt = ["DataInterpolations"]
-PlottingExt = ["Makie"]
+PlottingExt = ["LaTeXStrings", "Makie"]
 
 [compat]
 Aqua = "0.8"
-ComputePipeline = "0.1"
 DataInterpolations = "8.1"
 JET = "0.9, 0.10, 0.11"
 JLD2 = "0.6"
@@ -32,6 +29,7 @@ LaTeXStrings = "1"
 LazyArrays = "2.9"
 Makie = "0.21, 0.22, 0.23, 0.24"
 OrderedCollections = "1.8"
+Random = "1.10, 1.11, 1.12"
 Reexport = "1.2"
 Statistics = "1.10, 1.11"
 TestItemRunner = "1.1"
@@ -42,8 +40,10 @@ julia = "1.10, 1.11, 1.12"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "CairoMakie", "DataInterpolations", "JET", "Test", "Statistics"]
+test = ["Aqua", "CairoMakie", "DataInterpolations", "JET", "LaTeXStrings", "Test", "Statistics", "TestItemRunner"]

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -30,11 +30,18 @@ end
 """
     setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
 
-Dispatches setting properties of knot points as either setting a component or a property via `update!` or `setfield!`, respectively.
+Update a component of the knot point in-place via `update!`.
+
+Setting a struct field is not supported — `KnotPoint` is immutable and the
+data buffer is owned by the parent trajectory. Attempting to assign a struct
+field raises an error rather than silently aliasing through `setfield!`.
 """
 function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     if symb in fieldnames(KnotPoint)
-        setfield!(slice, symb, val) # will error (KnotPoint is an immutable struct)
+        error(
+            "KnotPoint is immutable; cannot set struct field :$symb. " *
+            "Use traj[i].name = data to update a trajectory component instead.",
+        )
     else
         update!(slice, symb, val)
     end

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -168,8 +168,10 @@ function NamedTrajectory(
     gcomps_data::NamedTuple{GN,<:Tuple{Vararg{AbstractVector{<:Real}}}} where {GN};
     kwargs...,
 )
-    # unpack data (promote type)
-    data = vcat([val for (key, val) ∈ pairs(comps_data)]...)
+    # unpack data (promote type). `vcat(values(comps_data)...)` preserves
+    # element types via the tuple — a list comprehension would widen to
+    # `Vector{<:AbstractMatrix{<:Real}}` and trip JET's type inference.
+    data = vcat(values(comps_data)...)
     dim, N = size(data)
 
     # save components of data matrix
@@ -183,7 +185,7 @@ function NamedTrajectory(
 
     # save global componets
     if !isempty(gcomps_data)
-        global_data = vcat([val for (key, val) ∈ pairs(gcomps_data)]...)
+        global_data = vcat(values(gcomps_data)...)
         global_dims_pairs = [(k => length(v)) for (k, v) ∈ pairs(gcomps_data)]
         gcomps_pairs = [(global_dims_pairs[1][1] => 1:global_dims_pairs[1][2])]
         for (k, v) ∈ global_dims_pairs[2:end]
@@ -229,8 +231,13 @@ function NamedTrajectory(
     comps_data::NamedTuple{N,<:Tuple{Vararg{AbstractVecOrMat{<:Real}}}} where {N};
     kwargs...,
 ) # where R <: Real
-    vals = [v isa AbstractVector ? reshape(v, 1, :) : v for v ∈ values(comps_data)]
-    comps_data = NamedTuple([(k => v) for (k, v) ∈ zip(keys(comps_data), vals)])
+    # `map` over a tuple preserves per-element types. A list comprehension would
+    # widen the result to `Vector{<:AbstractMatrix}` and lose information needed
+    # downstream; the corresponding `NamedTuple([k=>v ...])` reconstruction would
+    # then drop element typing entirely (which JET flags as a no-matching-method
+    # on the inner constructor).
+    vals = map(v -> v isa AbstractVector ? reshape(v, 1, :) : v, values(comps_data))
+    comps_data = NamedTuple{keys(comps_data)}(vals)
     return NamedTrajectory(comps_data; kwargs...)
 end
 

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,10 +1,5 @@
 @testitem "Aqua quality assurance" tags=[:aqua] begin
     using Aqua, NamedTrajectories
 
-    Aqua.test_all(
-        NamedTrajectories;
-        # TODO: drop ComputePipeline + LaTeXStrings; move TestItemRunner to [extras]
-        stale_deps = (ignore = [:ComputePipeline, :TestItemRunner, :LaTeXStrings],),
-        deps_compat = (check_extras = false, ignore = [:Random]),
-    )
+    Aqua.test_all(NamedTrajectories; deps_compat = (check_extras = false))
 end

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,5 +1,5 @@
 @testitem "Aqua quality assurance" tags=[:aqua] begin
     using Aqua, NamedTrajectories
 
-    Aqua.test_all(NamedTrajectories; deps_compat = (check_extras = false))
+    Aqua.test_all(NamedTrajectories)
 end

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -8,11 +8,7 @@
 @testitem "JET correctness analysis" tags=[:jet] begin
     if VERSION >= v"1.12"
         using JET, NamedTrajectories
-        JET.test_package(
-            NamedTrajectories;
-            target_modules = (NamedTrajectories,),
-            broken = true,
-        )  # TODO: 2 findings
+        JET.test_package(NamedTrajectories; target_modules = (NamedTrajectories,))
     else
         @info "Skipping JET correctness analysis on Julia $VERSION (requires >= 1.12)"
         @test true


### PR DESCRIPTION
## Summary

Clear the 2 JET findings and 4 Aqua findings surfaced by the test
infrastructure in #123.

### JET (2 → 0)

- **`setproperty!(::KnotPoint, ::Symbol, ::Any)`** previously called
  `setfield!` on the immutable `KnotPoint` for struct-field names — JET
  correctly flagged the guaranteed-error path. Replace with an explicit
  `error(\"KnotPoint is immutable; ...\")` that names the field and points
  users at the component-update API. Behavior unchanged; the existing
  `@test_throws ErrorException` continues to pass.
- **`rand(::Type{NamedTrajectory}, N)`** hit a no-matching-method on
  the inner `NamedTrajectory(::AbstractVector{<:Real}, ...)` because two
  list comprehensions in `struct_named_trajectory.jl` widened to
  `Vector{<:AbstractMatrix}` / `Vector{Any}`. Replace with `values(...)`
  + `map(...)` + `NamedTuple{keys}(tuple)` — type-stable enough for JET.

### Aqua (4 → 0)

- **Stale deps** (3): drop `ComputePipeline` (unused anywhere). Move
  `LaTeXStrings` to `[weakdeps]` and add it to the `PlottingExt`
  trigger (it is only used by the extension). Move `TestItemRunner`
  from `[deps]` to `[extras]` (only `runtests.jl` needs it; `TestItems`
  for `@testitem` stays a runtime dep).
- **Missing compat** for `Random` stdlib: add
  `Random = \"1.10, 1.11, 1.12\"` to `[compat]`.

Add `LaTeXStrings` and `TestItemRunner` to the test target so the
plotting / test-running entry points still resolve.

## Test plan

- [x] `Pkg.test()` green on Julia 1.12
- [x] `Aqua.test_all(NamedTrajectories; deps_compat=(check_extras=false,))` — 7 pass / 0 fail
- [x] `JET.report_package(NamedTrajectories; target_modules=(NamedTrajectories,))` — no errors detected
- [x] CI green on 1.10 / 1.11 / 1.12 + Documentation + Formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)