### PR TITLE
ci: gate force_latest_compatible_version to Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          # Default 'auto' forces latest-compatible versions on dependabot/CompatHelper
+          # PRs. JET compat is "0.9, 0.10, 0.11"; JET 0.10+ requires Julia 1.12, so
+          # forcing latest breaks resolution on 1.10/1.11. Restrict the force-latest
+          # behavior to 1.12 (where dependabot can actually exercise the new bound).
+          force_latest_compatible_version: ${{ matrix.version == '1.12' && 'auto' || 'false' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:


### PR DESCRIPTION
## Summary

`julia-actions/julia-runtest@v1` defaults `force_latest_compatible_version: auto`, which is `true` on Dependabot/CompatHelper PRs. With `JET = "0.9, 0.10, 0.11"` and JET 0.10+ requiring Julia 1.12, that forces the resolver to JET 0.11.x on every matrix row — and the 1.10 / 1.11 rows fail with `Unsatisfiable`.

This was the failure on the QuantumToolbox 0.46 dependabot PR (#201 here) and would block any future dependabot/compathelper PR.

Fix: gate `force_latest_compatible_version` so it only takes the `auto` default on Julia 1.12 (where JET actually runs) and is `false` on 1.10 / 1.11 (where Pkg can backtrack to JET 0.9.x normally).

The `if VERSION >= v"1.12"` runtime gate in `test/jet.jl` stays — Pkg still installs JET 0.9.x on older rows and we don't want `test_package` to execute there.

Same change going out to `NamedTrajectories.jl` and `DirectTrajOpt.jl` (both have identical JET setup).

## Test plan
- [ ] CI passes on this PR (1.10 / 1.11 should resolve JET 0.9.x; 1.12 unchanged)
- [ ] After merge, rebase / recreate the dependabot QuantumToolbox PR (#201) and confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)