### PR TITLE
ci: allow nightly Julia job to fail without blocking

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ jobs:
     name: Julia nightly - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    continue-on-error: true
     permissions:
       actions: write
       contents: read


### PR DESCRIPTION
## Summary

- Marks the `test` job in `.github/workflows/nightly.yml` as `continue-on-error: true` so transient pre-release Julia failures don't fail the workflow.
- Stable Julia versions in `CI.yml` still gate every PR and CompatHelper bump — nothing about resolver semantics on stable changes.

## Why

Julia `1.13.0-rc1` cannot resolve the test environment: `JET.jl` is pinned in `[compat]` but has no published release that declares Julia 1.13 compat, so Pkg has zero candidates.

Failing run: https://github.com/harmoniqs/NamedTrajectories.jl/actions/runs/26198797674

## Test plan

- [ ] CI on this PR is green (stable Julia matrix unaffected)
- [ ] Manually trigger the Nightly workflow after merge — confirm it runs, fails the resolver, but the workflow run is reported as success-with-warnings rather than red

🤖 Generated with [Claude Code](https://claude.com/claude-code)