### PR TITLE
ci: skip Julia test matrix on docs-only PRs (paths-ignore)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
       - main
     tags: ['*']
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.


### PR DESCRIPTION
Add `paths-ignore: ['docs/**', '*.md']` to the `pull_request` trigger so docs-only PRs skip the full Julia test matrix — matching Piccolo.jl / Legato.jl / Intonato.jl.

This PR still runs CI once (it edits `CI.yml` itself); subsequent docs-only PRs will skip it.