### PR TITLE
chore: autoformat test/test_utils.jl

### DIFF
--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -47,12 +47,8 @@ function named_trajectory_type_1(; free_time = false)
             Δt = ([0.1], [0.30000000000000004]),
         )
     else
-        components = (
-            Ũ⃗ = data[1:8, :],
-            a = data[9:10, :],
-            da = data[11:12, :],
-            dda = data[13:14, :],
-        )
+        components =
+            (Ũ⃗ = data[1:8, :], a = data[9:10, :], da = data[11:12, :], dda = data[13:14, :])
         controls = (:dda,)
         timestep = 0.2
         bounds = (a = ([-1.0, -1.0], [1.0, 1.0]), dda = ([-1.0, -1.0], [1.0, 1.0]))


### PR DESCRIPTION
Run JuliaFormatter (via the repo's own `Formatter.yml` `workflow_dispatch`, so it uses the exact CI formatter version) to fix the pre-existing formatting drift on `test/test_utils.jl` that was making the Formatter check red on `main`.

Pure whitespace/formatting; no semantic change. This makes the Formatter check green on `main` again.