### PR TITLE
Add get_global_components accessor

### DIFF
--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -1,6 +1,7 @@
 module MethodsNamedTrajectory
 
 export get_components
+export get_global_components
 export get_component_name
 export get_component_names
 
@@ -53,6 +54,13 @@ function get_components(cnames::Union{Tuple,AbstractVector}, traj::NamedTrajecto
 end
 
 get_components(traj::NamedTrajectory) = get_components(traj.names, traj)
+
+"""
+    get_global_components(::NamedTrajectory)
+
+Returns a NamedTuple containing the names and corresponding values of the global variables of the trajectory.
+"""
+get_global_components(traj::NamedTrajectory) = get_components(traj.global_names, traj)
 
 function filter_by_value(f::Function, nt::NamedTuple)
     return (; (k => v for (k, v) in pairs(nt) if f(v))...)


### PR DESCRIPTION
## Summary
- Adds `get_global_components(traj)`, mirroring `get_components(traj)` but scoped to `traj.global_names`
- Returns the trajectory's global variables as a `NamedTuple` (name => value) instead of the raw `global_data` vector

## Test plan
- [x] Manually verified `get_global_components(traj) == gcomps_data` for a trajectory constructed with global components