### PR TITLE
chore: bump to 0.9.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bump version 0.9.1 → 0.9.2 to release the `get_globals` accessor (#137). Patch bump — additive, non-breaking.